### PR TITLE
Latest dotnet sample app requires newer version of the AppD agent. Up…

### DIFF
--- a/appdynamics.auto.tfvars
+++ b/appdynamics.auto.tfvars
@@ -15,5 +15,5 @@ APPDYNAMICS_GLOBAL_ACCOUNT_NAME          = "fieldlabs_66c17af8-fcc7-4c41-a7a7-f7
 CORECLR_ENABLE_PROFILING                 = "1"
 CORECLR_PROFILER                         = "{57e1aa68-2229-41aa-9931-a6e93bbc64d8}"
 CORECLR_PROFILER_PATH                    = "/opt/appdynamics-agent/dotnet/libappdprofiler.so"
-APPDYNAMICS_AGENT_IMAGE                  = "appdynamics/dotnet-core-agent:20.7.0"
+APPDYNAMICS_AGENT_IMAGE                  = "appdynamics/dotnet-core-agent:21.7.0"
 APPDYNAMICS_AGENT_CONTAINER_NAME         = "AppDynamicsAgentContainer"

--- a/template/app.json.tpl
+++ b/template/app.json.tpl
@@ -94,9 +94,7 @@
         "Image": "${APPDYNAMICS_AGENT_IMAGE}",
         "Essential": false,
         "Command": [
-            "/bin/sh",
-            "-c",
-            "cp -r /opt/appdynamics/. /opt/temp"
+            "/opt/temp"
         ],
         "mountPoints": [
             {


### PR DESCRIPTION
The latest version of dotnet sample app (date: 6/23/21) requires newer version of the AppD agent. The newer agent's official docker image can no longer run the shell command. The update is to allow the project to use the latest version of the agent (21.7.0) and using dockerInstall from the agent image.